### PR TITLE
Add waitDebitObserve to get info about rate limiting.

### DIFF
--- a/token-limiter-concurrent/src/Control/Concurrent/TokenLimiter/Concurrent.hs
+++ b/token-limiter-concurrent/src/Control/Concurrent/TokenLimiter/Concurrent.hs
@@ -20,6 +20,7 @@ module Control.Concurrent.TokenLimiter.Concurrent
 where
 
 import Control.Concurrent
+import Control.Monad (void)
 import Data.Word
 import GHC.Clock
 import GHC.Generics (Generic)

--- a/token-limiter-concurrent/src/Control/Concurrent/TokenLimiter/Concurrent.hs
+++ b/token-limiter-concurrent/src/Control/Concurrent/TokenLimiter/Concurrent.hs
@@ -11,7 +11,7 @@ module Control.Concurrent.TokenLimiter.Concurrent
     canDebit,
     tryDebit,
     waitDebit,
-    MonotonicDiffNanos(..),
+    MonotonicDiffNanos (..),
     waitDebitObserve,
 
     -- * Helper functions

--- a/token-limiter-concurrent/src/Control/Concurrent/TokenLimiter/Concurrent.hs
+++ b/token-limiter-concurrent/src/Control/Concurrent/TokenLimiter/Concurrent.hs
@@ -45,7 +45,7 @@ data TokenLimitConfig = TokenLimitConfig
 -- This only exists because it is also a 'Word64' and would be too easy to confuse with a 'Count'.
 type MonotonicTime = Word64
 
-newtype MonotonicDiffNanos = MonotonicDiffNanos { unMonotonicDiffNanos :: Word64 }
+newtype MonotonicDiffNanos = MonotonicDiffNanos {unMonotonicDiffNanos :: Word64}
   deriving (Show, Eq, Ord, Generic)
 
 -- | A token bucket-based rate limiter


### PR DESCRIPTION
Specifically if it happened due to this action, and for how long.